### PR TITLE
IDM-114 Allowed call complete callback if auth failed

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1855,8 +1855,6 @@ function SugarApi(args) {
             if (!self.isLoginRequest(request.params.url)) {
                 _rqueue.push(request);
             }
-            // don't try to reauth again from here
-            self.setRefreshingToken(true);
 
             $(window).on('message', function(event) {
                 if (!event.originalEvent.origin || event.originalEvent.origin !== window.location.origin) {

--- a/test/client.js
+++ b/test/client.js
@@ -1538,6 +1538,30 @@ describe('Api client', function () {
                     expect(successStub).not.toHaveBeenCalled();
                 });
             });
+
+            it('should call complete callback if auth failed', function() {
+                const spyComplete = sinon.spy(this.callbacks, 'complete');
+
+                const responseBody = {
+                    error: 'need_login',
+                    error_message: 'some_error_message',
+                    url: 'some.url',
+                    platform: 'base',
+                };
+                this.server.respondWith('POST', 'rest/v10/oauth2/token?platform=base',
+                    [401, {'Content-Type': 'application/json'}, JSON.stringify(responseBody)]);
+                const api = Api.createInstance({
+                    serverUrl: '/rest/v10',
+                    keyValueStore: this.storage,
+                    platform: 'base',
+                });
+                api.setExternalLogin(true);
+
+                api.call('create', 'rest/v10/oauth2/token?platform=base', {}, this.callbacks);
+                this.server.respond();
+
+                sinon.assert.calledOnce(spyComplete);
+            });
         });
     });
 


### PR DESCRIPTION
`_refreshingToken` was used for complete callback fires only once, not twice as it was before. But on login it not fires complete callback. On merge need `sidecar/minified/sidecar.min.js`     