### PR TITLE
Fix tests that depend on jQuery-migrate behavior

### DIFF
--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -396,6 +396,39 @@ module.exports = {
             "response":"image"
         }
     },
+    '/rest/v10/Accounts': {
+        GET: {
+            status: 200,
+            response: {
+                next_offset: -1,
+                records: [
+                    {id: '5', name: 'ACME Corporation'}
+                ]
+            }
+        }
+    },
+    '/rest/v10/Bugs': {
+        GET: {
+            status: 200,
+            response: {
+                next_offset: -1,
+                records: [
+                    {id: '7', name: "It's a trap!"}
+                ]
+            }
+        }
+    },
+    '/rest/v10/Calls': {
+        GET: {
+            status: 200,
+            response: {
+                next_offset: -1,
+                records: [
+                    {id: '7', name: 'Talk about awesome product'}
+                ]
+            }
+        }
+    },
     responseErrors: {
         threehundred:{code: 300,body: "The value used for an external ID exists in more than one record. The response body contains the list of matching records."},
         fourhundred:{code: 400,body: 'The request could not be understood, usually because the JSON or XML body has an error.  This error code will also return all SQL errors from the server as well.'},


### PR DESCRIPTION
Previously, $.ajax would call its success callback with null
when given an empty string as the response body to a request
accepting a JSON response. This behavior was deprecated and
eventually removed, but restored by jQuery-migrate.

A number of tests were relying on this behavior, by sending
empty strings back from fake servers.

Fix these tests by giving them actual response JSON.

The tests now pass regardless of whether jQuery-migrate is present
or not.

Signed-off-by: Bob Wombat Hogg <rhogg@sugarcrm.com>

See https://jquery.com/upgrade-guide/1.9/#jquery-ajax-returning-a-json-result-of-an-empty-string