### PR TITLE
IDM-592 When SAML user logs out of sugar and clicks on Return to login, an error message shows up.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -389,6 +389,10 @@ function SugarApi(args) {
 
     var _handleErrorAndRefreshToken = function(self, request, callbacks) {
         return function(xhr, textStatus, errorThrown) {
+            // Don't handle aborted request as error
+            if (xhr.aborted || request.aborted) {
+                return;
+            }
             var error = new HttpError(request, textStatus, errorThrown);
             var onError = function() {
                 // Either regular request failed or token refresh failed

--- a/test/client.js
+++ b/test/client.js
@@ -1807,7 +1807,7 @@ describe('Api client', function () {
             expect(request.aborted).toBeTruthy();
 
             expect(sstub).not.toHaveBeenCalled();
-            expect(estub).toHaveBeenCalled();
+            expect(estub).not.toHaveBeenCalled();
             expect(cstub).toHaveBeenCalledWith(request);
 
             sstub.restore();


### PR DESCRIPTION
Don't need to handle errors on aborted request